### PR TITLE
Styling fix for firefox based browsers

### DIFF
--- a/src/css/Navbar.css
+++ b/src/css/Navbar.css
@@ -79,6 +79,7 @@
   .medium-small-navbar {
     right: 0;
     background-color: transparent;
+    box-shadow: none;
   }
 
   .medium-small-navbar .profile-image {
@@ -91,5 +92,10 @@
 
   .navbar-wrapper {
     margin: 10px;
+  }
+  /* Mozilla Fix */
+  .menu-button{
+    width: 70px;
+    height: 70px;
   }
 }


### PR DESCRIPTION
Some attributes don't inherit correctly so I added 3 rules to make them look the same as it looks on chromium

Before:
![image](https://github.com/user-attachments/assets/91e2db18-4261-4cc6-a891-99766249dd1f)

After:
![image](https://github.com/user-attachments/assets/a5b2aaa0-6543-48e3-9bcc-670f3a3e53cd)

